### PR TITLE
Adds prefix on `ssh_authenticator` call from `within`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,4 +39,4 @@ Config/Needs/website: insightsengineering/nesttemplate
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2

--- a/R/ssh_connector.R
+++ b/R/ssh_connector.R
@@ -142,7 +142,7 @@ ssh_connector <- function(data = teal.data::teal_data(),
           within(
             data,
             {
-              ssh_args <- teal.connector.ssh::ssh_authenticator(host = host)
+              ssh_args <- teal.connectors.ssh::ssh_authenticator(host = host)
               ssh_session <- ssh_args$session
             },
             host = host

--- a/R/ssh_connector.R
+++ b/R/ssh_connector.R
@@ -142,7 +142,7 @@ ssh_connector <- function(data = teal.data::teal_data(),
           within(
             data,
             {
-              ssh_args <- ssh_authenticator(host = host)
+              ssh_args <- teal.connector.ssh::ssh_authenticator(host = host)
               ssh_session <- ssh_args$session
             },
             host = host

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # `teal.connectors.ssh`: `teal` connector to access data via SSH
 
 <!-- start badges -->
-[![Check 🛠](https://github.com/insightsengineering/teal.connectors.ssh/actions/workflows/check.yaml/badge.svg)](https://insightsengineering.github.io/teal.connectors.ssh/main/unit-test-report/)
+[![Check 🛠](https://github.com/insightsengineering/teal.connectors.ssh/actions/workflows/check.yaml/badge.svg)](https://github.com/insightsengineering/teal.connectors.ssh/actions/workflows/check.yaml)
 [![Docs 📚](https://github.com/insightsengineering/teal.connectors.ssh/actions/workflows/docs.yaml/badge.svg)](https://insightsengineering.github.io/teal.connectors.ssh/)
 [![Code Coverage 📔](https://raw.githubusercontent.com/insightsengineering/teal.connectors.ssh/_xml_coverage_reports/data/main/badge.svg)](https://insightsengineering.github.io/teal.connectors.ssh/main/coverage-report/)
 
@@ -20,7 +20,7 @@
 <!-- end badges -->
 
 The `teal.connectors.ssh` package allows SSH data to be pulled into `teal` applications.
-The app developer can be used as a [`teal_data_module`](https://insightsengineering.github.io/teal/latest-tag/data-as-shiny-module.Rmd) in your `teal` application.
+The app developer can be used as a [`teal_data_module`](https://insightsengineering.github.io/teal/latest-tag/articles/data-as-shiny-module.html) in your `teal` application.
 
 ## Key features
 


### PR DESCRIPTION
# Pull Request

<!--- Replace `#nnn` with your issue link for reference. -->

Fixes #7

### How to test

- Have access to a server with ssh
- Have a `csv` file in that server
- Run code below adapting `PATH1`

```r
data <- teal.connectors.ssh::ssh_connector(
  paths = list(
    "PATH1" = "/path/to/file.csv"
  ),
  host = "127.0.0.1"
)

teal::init(
  data = data,
  modules = teal::modules(
    teal::example_module(label = "A"),
    teal::example_module(label = "B")
  )
)
```
